### PR TITLE
Return gracefully instead of using Environment.Exit

### DIFF
--- a/MSSQLand/Program.cs
+++ b/MSSQLand/Program.cs
@@ -34,9 +34,6 @@ namespace MSSQLand
             Logger.Banner($"Version: {currentVersion}\nCompile date: {compileDate:yyyy-MM-dd}", borderChar: '*');
             Logger.NewLine();
             int bannerWidth = Logger.Banner($"Executing from: {Environment.MachineName}\nTime Zone ID: {timeZoneId}\nLocal Time: {localTime:HH:mm:ss}, UTC Offset: {formattedOffset}");
-            Logger.NewLine();
-            Logger.Banner($"Start at {startTime:yyyy-MM-dd HH:mm:ss:fffff} UTC", totalWidth: bannerWidth);
-            Logger.NewLine();
 
             try
             {
@@ -61,6 +58,10 @@ namespace MSSQLand
                     Logger.Error("Invalid command arguments.");
                     return 1;
                 }
+
+                Logger.NewLine();
+                Logger.Banner($"Start at {startTime:yyyy-MM-dd HH:mm:ss:fffff} UTC", totalWidth: bannerWidth);
+                Logger.NewLine();
 
                 using AuthenticationService authService = new(arguments.Host);
 

--- a/MSSQLand/Program.cs
+++ b/MSSQLand/Program.cs
@@ -78,7 +78,15 @@ namespace MSSQLand
                     return 1;
                 }
 
-                DatabaseContext databaseContext = new(authService);
+                try
+                {
+                    using DatabaseContext databaseContext = new(authService);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error($"DatabaseContext initialization failed: {ex.Message}");
+                    return 1;
+                }
 
                 (string userName, string systemUser) = databaseContext.UserService.GetInfo();
 

--- a/MSSQLand/Program.cs
+++ b/MSSQLand/Program.cs
@@ -34,7 +34,8 @@ namespace MSSQLand
             Logger.Banner($"Version: {currentVersion}\nCompile date: {compileDate:yyyy-MM-dd}", borderChar: '*');
             Logger.NewLine();
             int bannerWidth = Logger.Banner($"Executing from: {Environment.MachineName}\nTime Zone ID: {timeZoneId}\nLocal Time: {localTime:HH:mm:ss}, UTC Offset: {formattedOffset}");
-
+            Logger.NewLine();
+            
             try
             {
                 CommandParser parser = new();
@@ -59,7 +60,6 @@ namespace MSSQLand
                     return 1;
                 }
 
-                Logger.NewLine();
                 Logger.Banner($"Start at {startTime:yyyy-MM-dd HH:mm:ss:fffff} UTC", totalWidth: bannerWidth);
                 Logger.NewLine();
 

--- a/MSSQLand/Program.cs
+++ b/MSSQLand/Program.cs
@@ -41,7 +41,7 @@ namespace MSSQLand
             try
             {
                 CommandParser parser = new();
-                var (result, arguments) = parser.Parse(args);
+                (CommandParser.ParseResultType result, CommandArgs? arguments) = parser.Parse(args);
 
                 switch (result)
                 {

--- a/MSSQLand/Program.cs
+++ b/MSSQLand/Program.cs
@@ -18,7 +18,7 @@ namespace MSSQLand
 
 
         [STAThread]
-        static void Main(string[] args)
+        static int Main(string[] args)
         {
 
             Stopwatch stopwatch = Stopwatch.StartNew();
@@ -37,6 +37,13 @@ namespace MSSQLand
                 CommandParser parser = new();
 
                 CommandArgs arguments = parser.Parse(args);
+
+                // if no arguments are returned the parser could already finish the user's request
+                // exit here. 
+                if (arguments == null)
+                {
+                    return 0;
+                }
 
                 Logger.Banner($"Version: {currentVersion}\nCompile date: {compileDate:yyyy-MM-dd}", borderChar: '*');
 
@@ -62,7 +69,7 @@ namespace MSSQLand
                  ))
                 {
                     Logger.Error("Failed to authenticate with the provided credentials.");
-                    return;
+                    return 1;
                 }
 
                 DatabaseContext databaseContext = new(authService);
@@ -98,6 +105,8 @@ namespace MSSQLand
                 Logger.NewLine();
                 Logger.Banner($"End at {endTime:yyyy-MM-dd HH:mm:ss:fffff} UTC\nTotal duration: {stopwatch.Elapsed.TotalSeconds:F2} seconds", totalWidth: bannerWidth);
 
+                return 0;
+
             }
             catch (Exception ex)
             {
@@ -112,7 +121,7 @@ namespace MSSQLand
                     Logger.Error($"Stack Trace: {ex.InnerException.StackTrace}");
                 }
 
-                Environment.Exit(1);
+                return 1;
             }
 
         }

--- a/MSSQLand/Program.cs
+++ b/MSSQLand/Program.cs
@@ -78,9 +78,10 @@ namespace MSSQLand
                     return 1;
                 }
 
+                DatabaseContext databaseContext;
                 try
                 {
-                    using DatabaseContext databaseContext = new(authService);
+                    databaseContext = new DatabaseContext(authService);
                 }
                 catch (Exception ex)
                 {

--- a/MSSQLand/Services/DatabaseContext.cs
+++ b/MSSQLand/Services/DatabaseContext.cs
@@ -29,7 +29,7 @@ namespace MSSQLand.Services
 
             if (HandleImpersonation() == false)
             {
-                Environment.Exit(1);
+                throw new Exception("Failed to handle impersonation. Exiting.");
             };
         }
 

--- a/MSSQLand/Utilities/CommandParser.cs
+++ b/MSSQLand/Utilities/CommandParser.cs
@@ -39,14 +39,14 @@ namespace MSSQLand.Utilities
             string additionalArguments = "";
 
             try {
-                foreach (var arg in args)
+                foreach (var originalArg in args)
                 {
+                    string arg = originalArg.ToLower();
+                    
                     if (arg.Contains("--"))
                     {
                         continue; // Skip any argument containing "--" (sliver thing)
                     }
-
-                    arg = arg.ToLower();
 
                     switch (arg)
                     {

--- a/MSSQLand/Utilities/CommandParser.cs
+++ b/MSSQLand/Utilities/CommandParser.cs
@@ -186,11 +186,9 @@ namespace MSSQLand.Utilities
 
                 return (ParseResultType.Success, parsedArgs);
             } catch (Exception ex) {
-                Logger.Error($"Parsing error occured: {ex.Message}");
-                return null;
+                Logger.Error($"Parsing error: {ex.Message}");
+                return (ParseResultType.InvalidInput, null);
             }
-
-            return parsedArgs;
         }
 
         private void ValidateCredentialArguments(string credentialType, string username, string password, string domain)

--- a/MSSQLand/Utilities/CommandParser.cs
+++ b/MSSQLand/Utilities/CommandParser.cs
@@ -49,12 +49,12 @@ namespace MSSQLand.Utilities
                     else if (arg.StartsWith("/help", StringComparison.OrdinalIgnoreCase))
                     {
                         Helper.Show();
-                        Environment.Exit(0);
+                        return null;
                     }
                     else if (arg.StartsWith("/printHelp", StringComparison.OrdinalIgnoreCase))
                     {
                         Helper.SaveCommandsToFile();
-                        Environment.Exit(0);
+                        return null;
                     }
                     else if (arg.StartsWith("/c:", StringComparison.OrdinalIgnoreCase) ||
                              arg.StartsWith("/credentials:", StringComparison.OrdinalIgnoreCase))
@@ -126,7 +126,7 @@ namespace MSSQLand.Utilities
                     BaseAction action = ActionFactory.GetEnumeration(enumType, parsedArgs.AdditionalArguments);
                     Logger.Task($"Executing action: {action.GetName()}");
                     action.Execute();
-                    Environment.Exit(0);
+                    return null;
                 }
 
 
@@ -175,7 +175,7 @@ namespace MSSQLand.Utilities
                 }
             } catch (Exception ex) {
                 Logger.Error($"Parsing error occured: {ex.Message}");
-                Environment.Exit(0);
+                return null;
             }
 
             return parsedArgs;

--- a/MSSQLand/Utilities/CommandParser.cs
+++ b/MSSQLand/Utilities/CommandParser.cs
@@ -8,6 +8,14 @@ namespace MSSQLand.Utilities
 {
     public class CommandParser
     {
+        public enum ParseResultType
+        {
+            Success,        // Parsing succeeded, return valid arguments.
+            ShowHelp,       // The user requested help (/help or /printHelp).
+            InvalidInput,   // User input is incorrect or missing required fields.
+            EnumerationMode // Enumeration mode detected, executed separately.
+        }
+        
         public static readonly Dictionary<string, List<string>> CredentialArgumentGroups = new()
         {
             { "token", new List<string>() },
@@ -38,25 +46,27 @@ namespace MSSQLand.Utilities
                         continue; // Skip any argument containing "--" (sliver thing)
                     }
 
-                    if (arg.Equals("/debug", StringComparison.OrdinalIgnoreCase))
+                    arg = arg.ToLower();
+
+                    switch (arg)
                     {
-                        Logger.IsDebugEnabled = true;
+                        case "/debug":
+                            Logger.IsDebugEnabled = true;
+                            continue;
+                        case "/s":
+                        case "/silent":
+                            Logger.IsSilentModeEnabled = true;
+                            continue;
+                        case "/help":
+                            Helper.Show();
+                            return (ParseResultType.ShowHelp, null);
+                        case "/printhelp":
+                            Helper.SaveCommandsToFile();
+                            return (ParseResultType.ShowHelp, null);
                     }
-                    else if (arg.StartsWith("/s", StringComparison.OrdinalIgnoreCase) || arg.Equals("/silent", StringComparison.OrdinalIgnoreCase))
-                    {
-                        Logger.IsSilentModeEnabled = true;
-                    }
-                    else if (arg.StartsWith("/help", StringComparison.OrdinalIgnoreCase))
-                    {
-                        Helper.Show();
-                        return null;
-                    }
-                    else if (arg.StartsWith("/printHelp", StringComparison.OrdinalIgnoreCase))
-                    {
-                        Helper.SaveCommandsToFile();
-                        return null;
-                    }
-                    else if (arg.StartsWith("/c:", StringComparison.OrdinalIgnoreCase) ||
+
+                    
+                    if (arg.StartsWith("/c:", StringComparison.OrdinalIgnoreCase) ||
                              arg.StartsWith("/credentials:", StringComparison.OrdinalIgnoreCase))
                     {
                         parsedArgs.CredentialType = ExtractValue(arg, "/c:", "/credentials:");
@@ -126,20 +136,20 @@ namespace MSSQLand.Utilities
                     BaseAction action = ActionFactory.GetEnumeration(enumType, parsedArgs.AdditionalArguments);
                     Logger.Task($"Executing action: {action.GetName()}");
                     action.Execute();
-                    return null;
+                    return (ParseResultType.EnumerationMode, null);
                 }
 
 
                 if (parsedArgs.Host == null)
                 {
-                    throw new ArgumentException("Targeted server (/h or /host) is mandatory. Use /help for more information");
+                    Logger.Error("Missing required argument: /h or /host.");
+                    return (ParseResultType.InvalidInput, null);
                 }
-                else
+
+
+                if (port.HasValue)
                 {
-                    if (port.HasValue)
-                    {
-                        parsedArgs.Host.Port = port.Value;
-                    }
+                    parsedArgs.Host.Port = port.Value;
                 }
 
 
@@ -173,6 +183,8 @@ namespace MSSQLand.Utilities
                     Logger.DebugNested($"Action: {parsedArgs.Action}");
                     Logger.DebugNested($"Additional Arguments: {parsedArgs.AdditionalArguments}");
                 }
+
+                return (ParseResultType.Success, parsedArgs);
             } catch (Exception ex) {
                 Logger.Error($"Parsing error occured: {ex.Message}");
                 return null;

--- a/MSSQLand/Utilities/CommandParser.cs
+++ b/MSSQLand/Utilities/CommandParser.cs
@@ -27,7 +27,7 @@ namespace MSSQLand.Utilities
 
         public const string AdditionalArgumentsSeparator = "/|/";
 
-        public CommandArgs Parse(string[] args)
+        public (ParseResultType, CommandArgs?) Parse(string[] args)
         {
             CommandArgs parsedArgs = new();
 


### PR DESCRIPTION
The application used to terminate on error conditions or on an early finished job (e.g. printing help), by calling Environment.Exit. When executing in-memory (e.g. using metasploit's `execute_dotnet_assembly`), this terminates the entire host process.

The changes allow to run the binary seamlessly from within your shell process, without killing it inadvertently. This is great if spawning another process and injecting into it is not an option. 

This is not yet thoroughly tested. 
Also, the changes are not this beautiful, yet. Especially the returning from the parser could be improved (see `Program.cs:41` onwards) but we get the job done without touching too much code for now.